### PR TITLE
Pick web targets file for web projects

### DIFF
--- a/src/CSProjToXProj/SourceFiles/FileReader.cs
+++ b/src/CSProjToXProj/SourceFiles/FileReader.cs
@@ -34,10 +34,18 @@ namespace CSProjToXProj.SourceFiles
                     .Except(new [] {"System"})
                     .ToArray();
 
+                var projectTypeGuids = doc
+                    .Descendants(XName.Get("ProjectTypeGuids", ns))
+                    .FirstOrDefault()?.Value
+                    .Split(';')
+                    .Select(Guid.Parse)
+                    .ToArray() ?? Array.Empty<Guid>();
+
                 return new ProjectMetadata(
                     targetFrameworkVersion: doc.Descendants(XName.Get("TargetFrameworkVersion", ns)).FirstOrDefault()?.Value,
                     rootNamespace: doc.Descendants(XName.Get("RootNamespace", ns)).FirstOrDefault()?.Value,
                     guid: Guid.Parse(doc.Descendants(XName.Get("ProjectGuid", ns)).FirstOrDefault()?.Value),
+                    projectTypeGuids: projectTypeGuids,
                     projectReferences: projectReferences,
                     frameworkReferences: frameworkReferences,
                     outputType: doc.Descendants(XName.Get("OutputType", ns)).FirstOrDefault()?.Value

--- a/src/CSProjToXProj/SourceFiles/ProjectMetadata.cs
+++ b/src/CSProjToXProj/SourceFiles/ProjectMetadata.cs
@@ -7,7 +7,7 @@ namespace CSProjToXProj.SourceFiles
     {
 
         public ProjectMetadata(string targetFrameworkVersion, string rootNamespace, Guid guid, string[] projectReferences, string[] frameworkReferences,
-            string outputType)
+            string outputType, params Guid[] projectTypeGuids)
         {
             TargetFrameworkVersion = targetFrameworkVersion;
             RootNamespace = rootNamespace;
@@ -15,6 +15,7 @@ namespace CSProjToXProj.SourceFiles
             ProjectReferences = projectReferences;
             FrameworkReferences = frameworkReferences;
             OutputType = outputType;
+            ProjectTypeGuids = new HashSet<Guid>(projectTypeGuids);
         }
         public string TargetFrameworkVersion { get; }
         public string RootNamespace { get;  }
@@ -22,5 +23,6 @@ namespace CSProjToXProj.SourceFiles
         public IReadOnlyList<string> ProjectReferences { get;  }
         public IReadOnlyList<string> FrameworkReferences { get;  }
         public string OutputType { get;}
+        public ISet<Guid> ProjectTypeGuids { get; }
     }
 }

--- a/src/CSProjToXProj/Writer.cs
+++ b/src/CSProjToXProj/Writer.cs
@@ -11,6 +11,8 @@ namespace CSProjToXProj
 {
     public class Writer
     {
+        public static readonly Guid WebProjectGuid = Guid.Parse("349C5851-65DF-11DA-9384-00065B846F21");
+
         private readonly IFileSystem _fileSystem;
 
         public Writer(IFileSystem fileSystem)
@@ -20,6 +22,10 @@ namespace CSProjToXProj
 
         public void WriteXProj(string xprojPath, ProjectMetadata projectMetaData)
         {
+            var targetsFilePath = projectMetaData.ProjectTypeGuids.Contains(WebProjectGuid)
+                ? "DotNet.Web\\Microsoft.DotNet.Web.targets"
+                : "DotNet\\Microsoft.DotNet.targets";
+
             var contents = $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <PropertyGroup>
@@ -36,7 +42,7 @@ namespace CSProjToXProj
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <Import Project=""$(VSToolsPath)\DotNet\Microsoft.DotNet.targets"" Condition=""'$(VSToolsPath)' != ''"" />
+  <Import Project=""$(VSToolsPath)\{targetsFilePath}"" Condition=""'$(VSToolsPath)' != ''"" />
 </Project>";
 
             _fileSystem.WriteAllText(xprojPath, contents);

--- a/src/Tests/WriterTests.cs
+++ b/src/Tests/WriterTests.cs
@@ -9,7 +9,7 @@ namespace Tests
 {
     public class WriterTests
     {
-        private readonly ProjectMetadata _metadata = new ProjectMetadata("v4.5.1", "MyProject.Namespace", Guid.Parse("50da3bcc-0fbb-4b69-8c7a-077f01fd6e4e"), new[] { "MyLib" }, new[] { "System.Data" }, "Exe");
+        private readonly ProjectMetadata _metadata = new ProjectMetadata("v4.5.1", "MyProject.Namespace", Guid.Parse("50da3bcc-0fbb-4b69-8c7a-077f01fd6e4e"), new[] { "MyLib" }, new[] { "System.Data" }, "Exe", Writer.WebProjectGuid);
 
         [Test]
         public void XProjIsWrittenCorrectly()
@@ -35,7 +35,7 @@ namespace Tests
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <Import Project=""$(VSToolsPath)\DotNet\Microsoft.DotNet.targets"" Condition=""'$(VSToolsPath)' != ''"" />
+  <Import Project=""$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets"" Condition=""'$(VSToolsPath)' != ''"" />
 </Project>".NormalizeLineEndings());
         }
 


### PR DESCRIPTION
This parses the `ProjectTypeGuids` node (if it exists) and checks if it contains the web project GUID (`349C5851-65DF-11DA-9384-00065B846F21`) in order to pick the correct targets file.

Closes #1
